### PR TITLE
Use "next" gatsby

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-env": "^7.0.0-rc.1"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "next"
   },
   "dependencies": {
     "webpack-bundle-analyzer": "^2.13.1"


### PR DESCRIPTION
While gatsby is still in v2-rc, should we set peer dep to use "next" instead?