### PR TITLE
Update peerdependency gatsby to not produce a warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "opn-cli": "^3.1.0"
   },
   "peerDependencies": {
-    "gatsby": "next"
+    "gatsby": ">=2.0.0"
   },
   "dependencies": {
     "webpack-bundle-analyzer": "^2.13.1"


### PR DESCRIPTION
I get 

```
warning " > gatsby-plugin-webpack-bundle-analyzer@1.0.3" has incorrect peer dependency "gatsby@next".
```

with gatsby 2.0.63

I didn't test if this changes fixes the warning