### PR TITLE
Remove 'production' option so that we always pass options to , except…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ See [original plugin](https://github.com/webpack-contrib/webpack-bundle-analyzer
 
 Additional options:
 
-- `production`: Run the analyzer on a production build. Defaults to `false`
 - `disable`: Set to true to toggle off the analyzer. Defaults to `false`
 
 ```javascript
@@ -39,8 +38,7 @@ plugins: [
 	{
 		resolve: 'gatsby-plugin-webpack-bundle-analyzer',
 		options: {
-			analyzerPort: 3000,
-			production: true,
+			analyzerPort: 3000
 		},
 	},
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-webpack-bundle-analyzer",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "A Gatsby plugin to help analyze your bundle content.",
   "scripts": {
     "build": "babel src --out-dir .",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,13 +1,8 @@
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 exports.onCreateWebpackConfig = ({ stage, actions }, options) => {
-	if(options.disable) return
-	if (
-		stage === 'develop' ||
-		(options.production && stage === 'build-javascript')
-	) {
-		actions.setWebpackConfig({
-			plugins: [new BundleAnalyzerPlugin(options)]
-		})
-	}
-}
+  if (options.disable) return;
+  actions.setWebpackConfig({
+    plugins: [new BundleAnalyzerPlugin(options)]
+  });
+};


### PR DESCRIPTION
_…_ if  option is set

See https://github.com/escaladesports/gatsby-plugin-webpack-bundle-analyzer/issues/11